### PR TITLE
Fix README links to SIGs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,16 @@ Foundation related resources like charters and code of conducts.
 <!-- TOC -->
 - [O3DE Resources](https://o3de.github.io/foundation/)
 - [SIG Meetings]
-  - [SIG-Build](https://o3de.github.io/foundation/sigs/sig-build/)
-  - [SIG-Content](https://o3de.github.io/foundation/sigs/sig-content/)
-  - [SIG-Core](https://o3de.github.io/foundation/sigs/sig-core/)
-  - [SIG-Docs](https://o3de.github.io/foundation/sigs/sig-docs/)
-  - [SIG-Network](https://o3de.github.io/foundation/sigs/sig-network/)
-  - [SIG-Platform](https://o3de.github.io/foundation/sigs/sig-platform/)
-  - [SIG-Presentation](https://o3de.github.io/foundation/sigs/sig-presentation/)
-  - [SIG-Release](https://o3de.github.io/foundation/sigs/sig-release/)
-  - [SIG-Security](https://o3de.github.io/foundation/sigs/sig-security/)
-  - [SIG-Testing](https://o3de.github.io/foundation/sigs/sig-testing/)
-  - [SIG-UI-UX](https://o3de.github.io/foundation/sigs/sig-ui-ux/)
+  - [SIG-Build](https://github.com/o3de/sig-build)
+  - [SIG-Content](https://github.com/o3de/sig-content)
+  - [SIG-Core](https://github.com/o3de/sig-core)
+  - [SIG-Docs](https://github.com/o3de/sig-docs-community)
+  - [SIG-Network](https://github.com/o3de/sig-network)
+  - [SIG-Platform](https://github.com/o3de/sig-platform)
+  - [SIG-Presentation](https://github.com/o3de/sig-graphics-audio)
+  - [SIG-Release](https://github.com/o3de/sig-release)
+  - [SIG-Security](https://github.com/o3de/sig-security)
+  - [SIG-Testing](https://github.com/o3de/sig-testing)
+  - [SIG-UI-UX](https://github.com/o3de/sig-ui-ux)
  
 <!-- /TOC -->


### PR DESCRIPTION
Signed-off-by: Stanko <stankoa@amazon.com>

Fixes https://github.com/o3de/community/issues/92 

* NOTE: `SIG-Presentation` seems to be called "sig-graphics-audio" now - should this be reflected in the README display name as well?

### testing
* see: https://github.com/allisaurus/community/blob/fix-readme/README.md

