### PR TITLE
Provide general guide to SIG governance

### DIFF
--- a/community-membership.md
+++ b/community-membership.md
@@ -4,7 +4,7 @@ Welcome to the Open 3D Engine! To learn more about contributing to the [O3DE cod
 
 The [O3DE community repo](https://github.com/o3de/community) contains information about how to get started, how the community organizes, and more.
 
-All contrubtors are required to follow our [Code of Conduct](https://github.com/o3de/o3de/blob/development/CODE_OF_CONDUCT.md).
+All contributors are required to follow our [Code of Conduct](https://github.com/o3de/o3de/blob/development/CODE_OF_CONDUCT.md).
 
 ## Contributing to Open 3D Engine
 

--- a/sigs/README.md
+++ b/sigs/README.md
@@ -43,4 +43,5 @@ To become a reviewer or a maintainer for a SIG, see the process in [community-me
 
 * General [GitHub issue triage guide](../sigs/docs/sig-issues-triage-guide.md) for SIG maintainers.
 * How to become a [reviewer or maintainer](../community-membership.md) for a SIG.
+* [SIG governance details](../sigs/docs/sig-governance.md) including roles of Chair(s)
 * [SIG chair elections process](../O3DE%20Elections/O3DE%20Elections%20Guide.md).

--- a/sigs/docs/sig-governance.md
+++ b/sigs/docs/sig-governance.md
@@ -1,0 +1,49 @@
+# Overview
+
+Open 3D engine's success is driven in part by its Special Interest Groups (SIGs). To standardize SIG efforts, create maximum transparency, and guide contributors towards the most relevant SIGs, SIGs should follow these guidelines:
+
+* Publish and maintain a charter, in their `governance` folder
+* Publish and maintain a README in their repro that helps describe what the SIG does, how it meets and how to get involved.
+* Meet regularly to [triage issues](sig-issues-triage-guide.md) and feature requests relevant to the SIG.
+* Meet regularly to discuss items of interest to the SIG.
+    * All meetings should be on the [public calendar](https://lists.o3de.org/g/o3de-calendar/calendar) 
+    * Notes should be maintained for these meetings.
+* Help maintain the public O3DE roadmaps.
+* Provide updates or attend the final monthly meeting of the [TSC](https://github.com/o3de/tsc) to help maintain roadmap.
+* Aid production of release notes/known issues when O3DE makes releases.
+
+# Governance
+
+All SIGs should have a chair and co-chair, elected on a 6-12 month cycle.
+
+The chair and co-chair serve equivalent roles in the governance of the SIG and are only differentiated by title in that the highest vote-getter is the chair and the second-highest is the co-chair. The chair and co-chair are expected to govern together in an effective way and split their responsibilities to make sure that the SIG operates smoothly and has the availability of a chairperson at any time.
+
+Unless **distinctly required**, the term "chairperson" refers to either/both of the chair and co-chair. If a chair or co-chair is required to perform a specific responsibility for the SIG they will always be addressed by their official role title.
+
+Chairs are not required to provide "on-call" support of any kind as part of their chairship. The O3D Foundation is responsible for addressing any high-severity issues related to documentation or community which would impact the immediate operation of the O3DE project or may result in legal liability of the O3D Foundation.
+
+## Responsibility of Chair(s)
+
+* Maintain the SIG charter and SIG related documentation.
+* Schedule and proctor regular SIG meetings on a cadence to be determined by the SIG.
+* Serve as a source of authority (and ideally wisdom) in regard to the SIG's area of discipline. Chairpersons are the ultimate arbiters of many standards, processes, and practices.
+* Participate in the SIG Discord channel and on the GitHub Discussion forums.
+* Serve as a representative of the broader O3DE community to all other SIGs, partners, the governing board, and the Linux Foundation.
+* Represent the SIG to O3DE partners, the governing board, and the Linux Foundation.
+* Coordinate with partners and the Linux Foundation regarding official community events.
+* Represent (or select/elect representatives) to maintain relationships with all other SIGs as well as the marketing committee.
+* Serve as an arbiter in SIG-related disputes.
+* Coordinate releases with SIG Release.
+* Assist contributors in finding resources and setting up official project or task infrastructure monitored/conducted by the SIG.
+* Long-term planning and strategy for the course of the SIG area of discipline for O3DE.
+* Maintain a release roadmap for the O3DE SIG area of discipline.
+
+Additional responsibilities will also be called out in each SIG's charter. For example [SIG-Network](https://github.com/o3de/sig-network/blob/main/governance/SIG%20Network%20Charter.md) charter calls out Chair(s) should have the responsibilities of reviewers and maintainers.
+
+## How do I become a Chair?
+
+SIGs hold regular elections, see the [election guide](../O3DE%20Elections/O3DE%20Elections%20Guide.md) for details.
+
+## How do I update this guide?
+
+Work with the TSC and SIG-Chairs to build consensus. Ensure at least two SIG chair(s) approve changes.


### PR DESCRIPTION
Provide a general SIG-governance guide.

Tasks:
- [ ] Ensure no prior version of this
- [ ] Bring to SIG-all
- [ ] Bring to TSC
- [ ] Advertise to SIG chairs so it can be linked from charter section "Additional responsibilities of Chairs" so common tasks can be removed.

Signed-off-by: Pip Potter <61438964+lmbr-pip@users.noreply.github.com>