### PR TITLE
Add docs links for physics features

### DIFF
--- a/features/sigjson/sig-simulation-features.json
+++ b/features/sigjson/sig-simulation-features.json
@@ -653,7 +653,7 @@
                 "Performance": "2",
                 "Platform": "1;",
                 "Link": "",
-                "Doc": "https://www.o3de.org/docs/user-guide/components/reference/physx/shape-collider/#colliders-as-triggers",
+                "Doc": "https://www.o3de.org/docs/user-guide/components/reference/physx/collider/#colliders-as-triggers, https://www.o3de.org/docs/user-guide/components/reference/physx/shape-collider/#colliders-as-triggers",
                 "Notes": "Usability issue with moving static triggers."
             },
             {


### PR DESCRIPTION
Signed-off-by: Tom Hulton-Harrop <82228511+hultonha@users.noreply.github.com>

Added docs links for physics features to the sig-simulation feature grid (tagging @lgleim, @epsilon-delta, @moraaar, @greerdv, @SergeyAMZN and @amzn-ahmadkrm for visibility).